### PR TITLE
Update Node.js version to 22 in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 22
 
       - name: Install Backend Dependencies
         run: |


### PR DESCRIPTION
## Summary
Change node version from 18 to 22 for LTS compatibility

## Related Issue
Closes #

## Type of Change
- [ ] Feature
- [ ] Bug fix
- [x] DevOps / Infrastructure
- [ ] Documentation
- [x] Refactor
- [ ] Tests

## Checklist
- [x] Code reviewed by self
- [x] No console errors
- [x] No secrets committed
- [x] Linked to project board
- [ ] Tests added (if applicable)
- [x] Documentation updated
